### PR TITLE
Fix build script path handling

### DIFF
--- a/sonadi-backend/build.sh
+++ b/sonadi-backend/build.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -o errexit
+cd "$(dirname "$0")"
 
 pip install -r ../requirements.txt
 python manage.py collectstatic --no-input


### PR DESCRIPTION
## Summary
- run build script commands from its own directory

## Testing
- `pre-commit --version`

------
https://chatgpt.com/codex/tasks/task_e_6875f5842ab0832fba38d0ae58cb7839